### PR TITLE
Make all non-bound functions inline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(tensorflow_cpp VERSION 1.0.2 LANGUAGES CXX)
+project(tensorflow_cpp VERSION 1.0.3 LANGUAGES CXX)
 
 find_package(ros_environment QUIET)
 if(ros_environment_FOUND)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 # DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "tensorflow_cpp"
-PROJECT_NUMBER         = 1.0.2
+PROJECT_NUMBER         = 1.0.3
 # PROJECT_BRIEF          =
 # PROJECT_LOGO           =
 # OUTPUT_DIRECTORY       =

--- a/include/tensorflow_cpp/graph_utils.h
+++ b/include/tensorflow_cpp/graph_utils.h
@@ -50,7 +50,7 @@ namespace tf = tensorflow;
  *
  * @return  tf::GraphDef     graph
  */
-tf::GraphDef loadFrozenGraph(const std::string& file) {
+inline tf::GraphDef loadFrozenGraph(const std::string& file) {
 
   tf::GraphDef graph_def;
   tf::Status status = tf::ReadBinaryProto(tf::Env::Default(), file, &graph_def);
@@ -71,7 +71,8 @@ tf::GraphDef loadFrozenGraph(const std::string& file) {
  * @return  true            if operation succeeded
  * @return  false           if operation failed
  */
-bool loadGraphIntoSession(tf::Session* session, const tf::GraphDef& graph_def) {
+inline bool loadGraphIntoSession(tf::Session* session,
+                                 const tf::GraphDef& graph_def) {
 
   tf::Status status = session->Create(graph_def);
   if (!status.ok())
@@ -93,7 +94,7 @@ bool loadGraphIntoSession(tf::Session* session, const tf::GraphDef& graph_def) {
  *
  * @return  tf::Session*                        session
  */
-tf::Session* loadFrozenGraphIntoNewSession(
+inline tf::Session* loadFrozenGraphIntoNewSession(
   const std::string& file, const bool allow_growth = true,
   const double per_process_gpu_memory_fraction = 0,
   const std::string& visible_device_list = "") {
@@ -114,7 +115,8 @@ tf::Session* loadFrozenGraphIntoNewSession(
  *
  * @return  std::vector<std::string>     list of input node names
  */
-std::vector<std::string> getGraphInputNames(const tf::GraphDef& graph_def) {
+inline std::vector<std::string> getGraphInputNames(
+  const tf::GraphDef& graph_def) {
 
   std::vector<std::string> input_nodes;
   for (const tf::NodeDef& node : graph_def.node()) {
@@ -132,7 +134,8 @@ std::vector<std::string> getGraphInputNames(const tf::GraphDef& graph_def) {
  *
  * @return  std::vector<std::string>     list of output node names
  */
-std::vector<std::string> getGraphOutputNames(const tf::GraphDef& graph_def) {
+inline std::vector<std::string> getGraphOutputNames(
+  const tf::GraphDef& graph_def) {
 
   std::vector<std::string> output_nodes;
   std::vector<std::string> nodes_with_outputs;
@@ -161,8 +164,8 @@ std::vector<std::string> getGraphOutputNames(const tf::GraphDef& graph_def) {
  *
  * @return  std::vector<int>     node shape
  */
-std::vector<int> getGraphNodeShape(const tf::GraphDef& graph_def,
-                                   const std::string& node_name) {
+inline std::vector<int> getGraphNodeShape(const tf::GraphDef& graph_def,
+                                          const std::string& node_name) {
 
   std::vector<int> node_shape;
   for (const tf::NodeDef& node : graph_def.node()) {
@@ -187,8 +190,8 @@ std::vector<int> getGraphNodeShape(const tf::GraphDef& graph_def,
  *
  * @return  tf::DataType     node datatype
  */
-tf::DataType getGraphNodeType(const tf::GraphDef& graph_def,
-                              const std::string& node_name) {
+inline tf::DataType getGraphNodeType(const tf::GraphDef& graph_def,
+                                     const std::string& node_name) {
 
   tf::DataType type = tf::DT_INVALID;
   for (const tf::NodeDef& node : graph_def.node()) {
@@ -214,7 +217,7 @@ tf::DataType getGraphNodeType(const tf::GraphDef& graph_def,
  *
  * @return  std::string   formatted info message
  */
-std::string getGraphInfoString(const tf::GraphDef& graph_def) {
+inline std::string getGraphInfoString(const tf::GraphDef& graph_def) {
 
   std::stringstream ss;
   ss << "FrozenGraph Info:" << std::endl;

--- a/include/tensorflow_cpp/saved_model_utils.h
+++ b/include/tensorflow_cpp/saved_model_utils.h
@@ -54,7 +54,7 @@ namespace tf = tensorflow;
  *
  * @return  tf::SavedModelBundleLite            SavedModel
  */
-tf::SavedModelBundleLite loadSavedModel(
+inline tf::SavedModelBundleLite loadSavedModel(
   const std::string& dir, const bool allow_growth = true,
   const double per_process_gpu_memory_fraction = 0,
   const std::string& visible_device_list = "") {
@@ -82,7 +82,7 @@ tf::SavedModelBundleLite loadSavedModel(
  *
  * @return  tf::Session*                        session
  */
-tf::Session* loadSavedModelIntoNewSession(
+inline tf::Session* loadSavedModelIntoNewSession(
   const std::string& dir, const bool allow_growth = true,
   const double per_process_gpu_memory_fraction = 0,
   const std::string& visible_device_list = "") {
@@ -102,7 +102,7 @@ tf::Session* loadSavedModelIntoNewSession(
  *
  * @return  tf::Session*  session
  */
-tf::Session* getSessionFromSavedModel(
+inline tf::Session* getSessionFromSavedModel(
   const tf::SavedModelBundleLite& saved_model) {
 
   return saved_model.GetSession();
@@ -121,7 +121,7 @@ tf::Session* getSessionFromSavedModel(
  *
  * @return  std::string     node name
  */
-std::string getSavedModelNodeByLayerName(
+inline std::string getSavedModelNodeByLayerName(
   const tf::SavedModelBundleLite& saved_model, const std::string& layer_name,
   const std::string& signature = "serving_default") {
 
@@ -156,7 +156,7 @@ std::string getSavedModelNodeByLayerName(
  *
  * @return  std::string     layer name
  */
-std::string getSavedModelLayerByNodeName(
+inline std::string getSavedModelLayerByNodeName(
   const tf::SavedModelBundleLite& saved_model, const std::string& node_name,
   const std::string& signature = "serving_default") {
 
@@ -195,7 +195,7 @@ std::string getSavedModelLayerByNodeName(
  *
  * @return  std::vector<std::string>     input names
  */
-std::vector<std::string> getSavedModelInputNames(
+inline std::vector<std::string> getSavedModelInputNames(
   const tf::SavedModelBundleLite& saved_model, const bool layer_names = false,
   const std::string& signature = "serving_default") {
 
@@ -236,7 +236,7 @@ std::vector<std::string> getSavedModelInputNames(
  *
  * @return  std::vector<std::string>     output names
  */
-std::vector<std::string> getSavedModelOutputNames(
+inline std::vector<std::string> getSavedModelOutputNames(
   const tf::SavedModelBundleLite& saved_model, const bool layer_names = false,
   const std::string& signature = "serving_default") {
 
@@ -270,7 +270,7 @@ std::vector<std::string> getSavedModelOutputNames(
  *
  * @return  std::vector<int>             node shape
  */
-std::vector<int> getSavedModelNodeShape(
+inline std::vector<int> getSavedModelNodeShape(
   const tf::SavedModelBundleLite& saved_model, const std::string& node_name,
   const std::string& signature = "serving_default") {
 
@@ -304,7 +304,7 @@ std::vector<int> getSavedModelNodeShape(
  *
  * @return  tf::DataType     node datatype
  */
-tf::DataType getSavedModelNodeType(
+inline tf::DataType getSavedModelNodeType(
   const tf::SavedModelBundleLite& saved_model, const std::string& node_name,
   const std::string& signature = "serving_default") {
 
@@ -337,7 +337,7 @@ tf::DataType getSavedModelNodeType(
  *
  * @return  std::string   formatted info message
  */
-std::string getSavedModelInfoString(
+inline std::string getSavedModelInfoString(
   const tf::SavedModelBundleLite& saved_model) {
 
   std::stringstream ss;

--- a/include/tensorflow_cpp/utils.h
+++ b/include/tensorflow_cpp/utils.h
@@ -49,7 +49,7 @@ namespace tf = tensorflow;
  *
  * @return  tf::SessionOptions                  session options
  */
-tf::SessionOptions makeSessionOptions(
+inline tf::SessionOptions makeSessionOptions(
   const bool allow_growth = true,
   const double per_process_gpu_memory_fraction = 0,
   const std::string& visible_device_list = "") {
@@ -75,9 +75,10 @@ tf::SessionOptions makeSessionOptions(
  *
  * @return  tf::Session*                        session
  */
-tf::Session* createSession(const bool allow_growth = true,
-                           const double per_process_gpu_memory_fraction = 0,
-                           const std::string& visible_device_list = "") {
+inline tf::Session* createSession(
+  const bool allow_growth = true,
+  const double per_process_gpu_memory_fraction = 0,
+  const std::string& visible_device_list = "") {
 
   tf::Session* session;
   tf::SessionOptions options = makeSessionOptions(

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
 
   <name>tensorflow_cpp</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>Wrappers around the TensorFlow C++ API for easy usage in ROS</description>
 
   <maintainer email="lennart.reiher@rwth-aachen.de">Lennart Reiher</maintainer>


### PR DESCRIPTION
This Pull request marks all non-bound functions as inline, as this solves issues when the header-only library is imported twice in any translation unit. (Reference, e.g. [here](https://github.com/ros/filters/issues/42))