### PR TITLE
Ignore "Assert" nodes as output nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(tensorflow_cpp VERSION 1.0.3 LANGUAGES CXX)
+project(tensorflow_cpp VERSION 1.0.4 LANGUAGES CXX)
 
 find_package(ros_environment QUIET)
 if(ros_environment_FOUND)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 # DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "tensorflow_cpp"
-PROJECT_NUMBER         = 1.0.3
+PROJECT_NUMBER         = 1.0.4
 # PROJECT_BRIEF          =
 # PROJECT_LOGO           =
 # OUTPUT_DIRECTORY       =

--- a/include/tensorflow_cpp/graph_utils.h
+++ b/include/tensorflow_cpp/graph_utils.h
@@ -140,7 +140,8 @@ inline std::vector<std::string> getGraphOutputNames(
   std::vector<std::string> output_nodes;
   std::vector<std::string> nodes_with_outputs;
   std::unordered_set<std::string> unlikely_output_ops = {"Const", "Assign",
-                                                         "NoOp", "Placeholder"};
+                                                         "NoOp", "Placeholder",
+                                                         "Assert"};
   for (const tf::NodeDef& node : graph_def.node()) {
     for (const std::string& input_name : node.input())
       nodes_with_outputs.push_back(input_name);

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
 
   <name>tensorflow_cpp</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <description>Wrappers around the TensorFlow C++ API for easy usage in ROS</description>
 
   <maintainer email="lennart.reiher@rwth-aachen.de">Lennart Reiher</maintainer>


### PR DESCRIPTION
This PR also ignores all "Assert" nodes when trying to find out the output nodes of a frozen graph. Also, the version number is bumped to 1.0.4.