### PR TITLE
Make Model::operator() const

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(tensorflow_cpp VERSION 1.0.5 LANGUAGES CXX)
+project(tensorflow_cpp VERSION 1.0.6 LANGUAGES CXX)
 
 find_package(ros_environment QUIET)
 if(ros_environment_FOUND)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 # DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "tensorflow_cpp"
-PROJECT_NUMBER         = 1.0.5
+PROJECT_NUMBER         = 1.0.6
 # PROJECT_BRIEF          =
 # PROJECT_LOGO           =
 # OUTPUT_DIRECTORY       =

--- a/include/tensorflow_cpp/model.h
+++ b/include/tensorflow_cpp/model.h
@@ -162,7 +162,7 @@ class Model {
    */
   std::unordered_map<std::string, tf::Tensor> operator()(
     const std::vector<std::pair<std::string, tf::Tensor>>& inputs,
-    const std::vector<std::string>& output_names) {
+    const std::vector<std::string>& output_names) const{
 
     // properly set input/output names for session->Run()
     std::vector<std::pair<std::string, tf::Tensor>> input_nodes;
@@ -170,9 +170,9 @@ class Model {
     if (is_saved_model_) {
       for (const auto& input : inputs)
         input_nodes.push_back(
-          {saved_model_layer2node_[input.first], input.second});
+          {saved_model_layer2node_.find(input.first)->second, input.second});
       for (const auto& name : output_names)
-        output_node_names.push_back(saved_model_layer2node_[name]);
+        output_node_names.push_back(saved_model_layer2node_.find(name)->second);
     } else if (is_frozen_graph_) {
       input_nodes = inputs;
       output_node_names = output_names;
@@ -207,7 +207,7 @@ class Model {
    *
    * @return  tf::Tensor       output tensor
    */
-  tf::Tensor operator()(const tf::Tensor& input_tensor) {
+  tf::Tensor operator()(const tf::Tensor& input_tensor) const {
 
     if (n_inputs_ != 1 || n_outputs_ != 1) {
       throw std::runtime_error(
@@ -235,7 +235,7 @@ class Model {
    * @return  std::vector<tf::Tensor>     output tensors
    */
   std::vector<tf::Tensor> operator()(
-    const std::vector<tf::Tensor>& input_tensors) {
+    const std::vector<tf::Tensor>& input_tensors) const {
 
     if (input_tensors.size() != n_inputs_) {
       throw std::runtime_error(

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="3">
 
   <name>tensorflow_cpp</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Wrappers around the TensorFlow C++ API for easy usage in ROS</description>
 
   <maintainer email="lennart.reiher@rwth-aachen.de">Lennart Reiher</maintainer>


### PR DESCRIPTION
As `Model::operator()` doesn't change the model itself, it should be declared `const`.
For this to work, we cannot use `std::unordererd_map::operator[](Key & key)`, inside it, because that would insert a new value if, the key didn't exist. As alternative, we can use `std::unordered_map::find(Key & key)`, which would throw if the key didn't exist - a behavior that also seems more intuitive to me.